### PR TITLE
Adding visual nodes support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,9 @@ add_executable(${PROJECT_NAME}-bin
   src/main.cpp
   src/althack/main_window.cpp
   src/althack/backend.cpp
-  src/althack/backends/server_backend.cpp)
+  src/althack/backends/server_backend.cpp
+  src/althack/visuals/node.cpp
+  src/althack/visuals/account_node.cpp)
 
 target_link_libraries(${PROJECT_NAME}
   imgui

--- a/include/althack/main_window.hpp
+++ b/include/althack/main_window.hpp
@@ -1,15 +1,25 @@
 #ifndef ALTHACK_MAINWINDOW_HPP_
 #define ALTHACK_MAINWINDOW_HPP_
 
+// Standard
+#include <memory>
 #include <string>
+#include <vector>
 
+// spdlog
 #include <spdlog/spdlog.h>
 
+// ImGUI
 #include <imgui.h>
 #include <imgui_impl_sdl.h>
 #include <imgui_impl_sdlrenderer.h>
 
+// SDL
 #include <SDL.h>
+
+// AltHack
+#include <althack/visuals/node.hpp>
+#include <althack/visuals/account_node.hpp>
 
 namespace althack {
 
@@ -60,6 +70,14 @@ class MainWindow {
   std::string getSdlVersionLinked() const;
 
  private:
+  //! \brief Reference to a node visual, alongside its current visual state.
+  typedef struct StatefulNode {
+    //! \brief Reference to the node visual
+    std::shared_ptr<visuals::Node> node;
+    //! \brief The drawing position of the node visual
+    ImVec2 position;
+  } StatefulNode;
+
   //! \brief Creates the main canvas widget based on the specified parameters.
   /*!
     \param identifier The string identifier of this widget.
@@ -67,6 +85,13 @@ class MainWindow {
     \param position The scroll position to use as drawing origin in canvas coordinates.
    */
   void canvas(const std::string& identifier, const ImVec2 size, const ImVec2 position);
+
+  //! \brief Adds a visual node element.
+  /*!
+    \param node The node instance to add.
+    \param position The canvas coordinates this node is positioned at initially.
+   */
+  void addNode(std::shared_ptr<visuals::Node> node, const ImVec2& position);
 
   //! \brief Renders the root window.
   /*!
@@ -86,6 +111,9 @@ class MainWindow {
 
   //! \brief The canvas position when dragging started.
   ImVec2 drag_start_position_;
+
+  //! \brief List of node visuals to draw, alongside their state data.
+  std::vector<StatefulNode> nodes_;
 };
 
 }  // namespace althack

--- a/include/althack/main_window.hpp
+++ b/include/althack/main_window.hpp
@@ -2,9 +2,9 @@
 #define ALTHACK_MAINWINDOW_HPP_
 
 // Standard
+#include <list>
 #include <memory>
 #include <string>
-#include <vector>
 
 // spdlog
 #include <spdlog/spdlog.h>
@@ -76,6 +76,7 @@ class MainWindow {
     std::shared_ptr<visuals::Node> node;
     //! \brief The drawing position of the node visual
     ImVec2 position;
+    bool dragged;
   } StatefulNode;
 
   //! \brief Creates the main canvas widget based on the specified parameters.
@@ -112,8 +113,14 @@ class MainWindow {
   //! \brief The canvas position when dragging started.
   ImVec2 drag_start_position_;
 
+  bool was_dragging_;
+
+  StatefulNode* dragged_node_;
+
+  StatefulNode* hovered_node_;
+
   //! \brief List of node visuals to draw, alongside their state data.
-  std::vector<StatefulNode> nodes_;
+  std::list<StatefulNode> nodes_;
 };
 
 }  // namespace althack

--- a/include/althack/main_window.hpp
+++ b/include/althack/main_window.hpp
@@ -9,7 +9,7 @@
 // spdlog
 #include <spdlog/spdlog.h>
 
-// ImGUI
+// ImGui
 #include <imgui.h>
 #include <imgui_impl_sdl.h>
 #include <imgui_impl_sdlrenderer.h>
@@ -41,31 +41,41 @@ class MainWindow {
     \param width The window width in pixels.
     \param height The window height in pixels.
     \sa teardown()
+    \returns A boolean flag denoting whether the setup was completed successfully.
    */
   bool setup(const std::string& title, uint32_t width, uint32_t height);
 
   //! \brief Processes high level I/O signals to allow window interaction.
+  /*!
+    \returns A boolean flag denoting whether I/O was processed successfully.
+   */
   bool processIo();
 
   //! \brief Renders this window instance based on its current state.
+  /*!
+    \returns A boolean flag denoting whether rendering was processed successfully.
+   */
   bool render();
 
   //! \brief Tears down this window instance.
   /*!
     Internal clean-up mechanisms are executed to ensure a clean teardown.
     \sa setup()
+    \returns A boolean flag denoting whether teardown was processed successfully.
    */
   bool teardown();
 
   //! \brief Returns the semantic version string of the compiled SDL libraries.
   /*!
     \sa getSdlVersionLinked()
+    \returns A string representation of the semantic SDL version (compile version).
    */
   std::string getSdlVersionCompiled() const;
 
   //! \brief Returns the semantic version string of the linked SDL libraries.
   /*!
     \sa getSdlVersionCompiled()
+    \returns A string representation of the semantic SDL version (link version).
    */
   std::string getSdlVersionLinked() const;
 
@@ -76,6 +86,7 @@ class MainWindow {
     std::shared_ptr<visuals::Node> node;
     //! \brief The drawing position of the node visual
     ImVec2 position;
+    //! \brief Denotes whether the node is currently being dragged
     bool dragged;
   } StatefulNode;
 
@@ -113,10 +124,13 @@ class MainWindow {
   //! \brief The canvas position when dragging started.
   ImVec2 drag_start_position_;
 
+  //! \brief Denotes whether an element was being dragged in the past frame.
   bool was_dragging_;
 
+  //! \brief Stores a pointer to the currently dragged node.
   StatefulNode* dragged_node_;
 
+  //! \brief Stores a pointer to the currently hovered node.
   StatefulNode* hovered_node_;
 
   //! \brief List of node visuals to draw, alongside their state data.

--- a/include/althack/visuals/account_node.hpp
+++ b/include/althack/visuals/account_node.hpp
@@ -1,0 +1,23 @@
+#ifndef ALTHACK_VISUALS_ACCOUNT_NODE_HPP_
+#define ALTHACK_VISUALS_ACCOUNT_NODE_HPP_
+
+// AltHack
+#include <althack/visuals/node.hpp>
+
+namespace althack {
+namespace visuals {
+
+//! \brief Funds holding account node class.
+class AccountNode : public Node {
+ public:
+  AccountNode(const std::string& identifier);
+
+  void draw(const ImVec2 position) override;
+
+  ImVec2 size() const override;
+};
+
+}  // namespace visuals
+}  // namespace althack
+
+#endif  // ALTHACK_VISUALS_ACCOUNT_NODE_HPP_

--- a/include/althack/visuals/account_node.hpp
+++ b/include/althack/visuals/account_node.hpp
@@ -12,9 +12,11 @@ class AccountNode : public Node {
  public:
   AccountNode(const std::string& identifier);
 
-  void draw(const ImVec2 position) override;
+  void draw(const ImVec2 position, bool hovered, bool dragged) override;
 
   ImVec2 size() const override;
+
+  bool hit(const ImVec2 node_position, const ImVec2 hit_position) const override;
 };
 
 }  // namespace visuals

--- a/include/althack/visuals/account_node.hpp
+++ b/include/althack/visuals/account_node.hpp
@@ -10,13 +10,44 @@ namespace visuals {
 //! \brief Funds holding account node class.
 class AccountNode : public Node {
  public:
-  AccountNode(const std::string& identifier);
+  //! \brief Initializes this instance.
+  /*!
+    \param identifier The internal string identifier, passed to the Node superclass.
+    \param provider The provider identifier for the provider that holds this account.
+    \param account The account identifier at the provider.
+    \param amount The initial funds amount held by this account.
+    \param currency The currency identifier for this account.
+   */
+  AccountNode(
+      const std::string& identifier, const std::string& provider,
+      const std::string& account, double amount, const std::string& currency);
 
   void draw(const ImVec2 position, bool hovered, bool dragged) override;
 
   ImVec2 size() const override;
 
-  bool hit(const ImVec2 node_position, const ImVec2 hit_position) const override;
+  //! \brief Sets the amount this visual node displays.
+  /*!
+    \param amount The currency amount to display for this account node.
+   */
+  void setAmount(double amount);
+
+  const std::string& getProvider() const;
+
+  const std::string& getAccount() const;
+
+ private:
+  //! \brief The provider identifier for the provider that holds this account.
+  const std::string provider_;
+
+  //! \brief The account identifier at the provider.
+  const std::string account_;
+
+  //! \brief The initial funds amount held by this account.
+  const std::string currency_;
+
+  //! \brief The currency identifier for this account.
+  double amount_;
 };
 
 }  // namespace visuals

--- a/include/althack/visuals/node.hpp
+++ b/include/althack/visuals/node.hpp
@@ -4,7 +4,7 @@
 // Standard
 #include <string>
 
-// ImGUI
+// ImGui
 #include <imgui.h>
 
 namespace althack {
@@ -13,17 +13,41 @@ namespace visuals {
 //! \brief Abstract base class for visual node elements.
 class Node {
  public:
+  //! \brief Initializes this instance.
+  /*!
+    \param identifier The internal string identifier of this node.
+   */
   Node(const std::string& identifier);
 
+  //! \brief Returns the internal string identifier of this node.
   const std::string& getIdentifier() const;
 
+  //! \brief Draws this node on the current canvas.
+  /*!
+    \param position At which canvas position to draw this node
+    \param hovered Denotes whether this node is currently hovered over
+    \param dragged Denotes whether this node is currently being dragged
+   */
   virtual void draw(const ImVec2 position, bool hovered, bool dragged) = 0;
 
+  //! \brief Returns the visual size of this node.
+  /*!
+    Needs to be overridden by subclasses. The return value of this function
+    affects the hit() test for this node.
+    \returns The two-dimensional area representing the visual size of this node.
+   */
   virtual ImVec2 size() const = 0;
 
-  virtual bool hit(const ImVec2 node_position, const ImVec2 hit_position) const = 0;
+  //! \brief Determines whether a hit position is within the visual area of this node.
+  /*!
+    \param node_position The position at which the node visual is located at
+    \param hit_position The position to test for in the hit test
+    \returns A boolean flag denoting whether hit_position is within the visual node area.
+   */
+  virtual bool hit(const ImVec2 node_position, const ImVec2 hit_position) const;
 
  private:
+  //! \brief The internal string identifier of this node.
   const std::string identifier_;
 };
 

--- a/include/althack/visuals/node.hpp
+++ b/include/althack/visuals/node.hpp
@@ -17,9 +17,11 @@ class Node {
 
   const std::string& getIdentifier() const;
 
-  virtual void draw(const ImVec2 position) = 0;
+  virtual void draw(const ImVec2 position, bool hovered, bool dragged) = 0;
 
   virtual ImVec2 size() const = 0;
+
+  virtual bool hit(const ImVec2 node_position, const ImVec2 hit_position) const = 0;
 
  private:
   const std::string identifier_;

--- a/include/althack/visuals/node.hpp
+++ b/include/althack/visuals/node.hpp
@@ -1,0 +1,31 @@
+#ifndef ALTHACK_VISUALS_NODE_HPP_
+#define ALTHACK_VISUALS_NODE_HPP_
+
+// Standard
+#include <string>
+
+// ImGUI
+#include <imgui.h>
+
+namespace althack {
+namespace visuals {
+
+//! \brief Abstract base class for visual node elements.
+class Node {
+ public:
+  Node(const std::string& identifier);
+
+  const std::string& getIdentifier() const;
+
+  virtual void draw(const ImVec2 position) = 0;
+
+  virtual ImVec2 size() const = 0;
+
+ private:
+  const std::string identifier_;
+};
+
+}  // namespace visuals
+}  // namespace althack
+
+#endif  // ALTHACK_VISUALS_NODE_HPP_

--- a/src/althack/main_window.cpp
+++ b/src/althack/main_window.cpp
@@ -8,8 +8,11 @@ namespace althack {
 
 MainWindow::MainWindow()
   : window_{nullptr}
-  , renderer_{nullptr} {
-  addNode(std::make_shared<visuals::AccountNode>("node"), ImVec2(0, 0));
+  , renderer_{nullptr}
+  , was_dragging_{false}
+  , dragged_node_{nullptr} {
+  addNode(std::make_shared<visuals::AccountNode>("node1"), ImVec2(0, 0));
+  addNode(std::make_shared<visuals::AccountNode>("node2"), ImVec2(250, 75));
 }
 
 bool MainWindow::setup(const std::string& title, uint32_t width, uint32_t height) {
@@ -131,19 +134,70 @@ void MainWindow::canvas(const std::string& identifier, const ImVec2 size, const 
     draw_list->AddLine(startn, endn, row % substeps_rows == 0 ? grid_col_major : grid_col_minor);
   }
 
+  // Find out which node is hovered, if any
+  hovered_node_ = nullptr;
+  const ImVec2 mouse_position = ImGui::GetMousePos();
+  for (std::list<StatefulNode>::reverse_iterator node_iter = nodes_.rbegin();
+       node_iter != nodes_.rend(); ++node_iter) {
+    StatefulNode& node = *node_iter;
+    const ImVec2 node_position = size / 2.0 + bb.Min + position + node.position;
+    // Only one node is hovered at all times.
+    const bool hovered = hovered_node_ == nullptr && node.node->hit(node_position, mouse_position);
+
+    if (hovered) {
+      hovered_node_ = &node;
+      break;
+    }
+  }
+
   // Draw nodes
   for (const StatefulNode& node : nodes_) {
-    node.node->draw(size / 2.0 + bb.Min + position + node.position);
+    const ImVec2 node_position = size / 2.0 + bb.Min + position + node.position;
+    const bool hovered = hovered_node_ != nullptr && hovered_node_->node == node.node;
+    node.node->draw(node_position, hovered, node.dragged);
   }
 
   // Handle UI interaction
   if (ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
     const ImVec2 clicked_pos = ImGui::GetIO().MouseClickedPos[0];
+
+    if (!was_dragging_) {
+      // Check if we need to start dragging a node or the canvas.
+      for (std::list<StatefulNode>::iterator node_iter = nodes_.begin();
+           node_iter != nodes_.end(); ++node_iter) {
+        StatefulNode& node = *node_iter;
+        if (!(hovered_node_ != nullptr && hovered_node_->node == node.node)) {
+          continue;
+        }
+
+        dragged_node_ = &node;
+        dragged_node_->dragged = true;
+        drag_start_position_ = node.position;
+
+        // Move node to end of list (to draw it on top of everything else).
+        nodes_.splice(nodes_.end(), nodes_, node_iter);
+        break;
+      }
+    }
+
     if (bb.Contains(clicked_pos)) {
-      canvas_position_ = drag_start_position_ + ImGui::GetMouseDragDelta();
+      if (dragged_node_ == nullptr) {
+        // Dragging the canvas.
+        canvas_position_ = drag_start_position_ + ImGui::GetMouseDragDelta();
+      } else {
+        // Dragging a node.
+        dragged_node_->position = drag_start_position_ + ImGui::GetMouseDragDelta();
+      }
+
+      was_dragging_ = true;
     }
   } else {
     drag_start_position_ = canvas_position_;
+    was_dragging_ = false;
+    if (dragged_node_ != nullptr) {
+      dragged_node_->dragged = false;
+    }
+    dragged_node_ = nullptr;
   }
 
   ImGui::PopClipRect();

--- a/src/althack/main_window.cpp
+++ b/src/althack/main_window.cpp
@@ -9,6 +9,7 @@ namespace althack {
 MainWindow::MainWindow()
   : window_{nullptr}
   , renderer_{nullptr} {
+  addNode(std::make_shared<visuals::AccountNode>("node"), ImVec2(0, 0));
 }
 
 bool MainWindow::setup(const std::string& title, uint32_t width, uint32_t height) {
@@ -69,6 +70,7 @@ void MainWindow::canvas(const std::string& identifier, const ImVec2 size, const 
 
   const ImGuiID id = window->GetID(identifier.c_str());
   const ImRect bb(window->DC.CursorPos, window->DC.CursorPos + size);
+  ImGui::PushClipRect(bb.Min, bb.Max, false);
   ImGuiContext& g = *GImGui;
   ImGui::ItemSize(size, g.Style.FramePadding.y);
   if (!ImGui::ItemAdd(bb, id))
@@ -129,6 +131,11 @@ void MainWindow::canvas(const std::string& identifier, const ImVec2 size, const 
     draw_list->AddLine(startn, endn, row % substeps_rows == 0 ? grid_col_major : grid_col_minor);
   }
 
+  // Draw nodes
+  for (const StatefulNode& node : nodes_) {
+    node.node->draw(size / 2.0 + bb.Min + position + node.position);
+  }
+
   // Handle UI interaction
   if (ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
     const ImVec2 clicked_pos = ImGui::GetIO().MouseClickedPos[0];
@@ -139,7 +146,13 @@ void MainWindow::canvas(const std::string& identifier, const ImVec2 size, const 
     drag_start_position_ = canvas_position_;
   }
 
+  ImGui::PopClipRect();
+
   IMGUI_TEST_ENGINE_ITEM_INFO(id, identifier.c_str(), g.LastItemData.StatusFlags);
+}
+
+void MainWindow::addNode(std::shared_ptr<visuals::Node> node, const ImVec2& position) {
+  nodes_.push_back({node, position});
 }
 
 void MainWindow::rootWindow() {

--- a/src/althack/main_window.cpp
+++ b/src/althack/main_window.cpp
@@ -1,6 +1,6 @@
 #include <althack/main_window.hpp>
 
-#include <iostream>
+#include <map>
 #define IMGUI_DEFINE_MATH_OPERATORS
 #include <imgui_internal.h>
 
@@ -11,8 +11,8 @@ MainWindow::MainWindow()
   , renderer_{nullptr}
   , was_dragging_{false}
   , dragged_node_{nullptr} {
-  addNode(std::make_shared<visuals::AccountNode>("node1"), ImVec2(0, 0));
-  addNode(std::make_shared<visuals::AccountNode>("node2"), ImVec2(250, 75));
+  addNode(std::make_shared<visuals::AccountNode>("node1", "rainforest", "acc123", 100.0, "$"), ImVec2(0, 0));
+  addNode(std::make_shared<visuals::AccountNode>("node2", "paybuddy", "acc@pb.domain", 52.75, "EUR"), ImVec2(250, 75));
 }
 
 bool MainWindow::setup(const std::string& title, uint32_t width, uint32_t height) {
@@ -153,51 +153,60 @@ void MainWindow::canvas(const std::string& identifier, const ImVec2 size, const 
   // Draw nodes
   for (const StatefulNode& node : nodes_) {
     const ImVec2 node_position = size / 2.0 + bb.Min + position + node.position;
+    // Check if the node is currently visible, based on its position and size.
+    // If not, don't draw it.
+    if (!bb.Overlaps(ImRect(node_position - node.node->size() / 2.0,
+                            node_position + node.node->size() / 2.0))) {
+      continue;
+    }
+
     const bool hovered = hovered_node_ != nullptr && hovered_node_->node == node.node;
     node.node->draw(node_position, hovered, node.dragged);
   }
 
-  // Handle UI interaction
-  if (ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
-    const ImVec2 clicked_pos = ImGui::GetIO().MouseClickedPos[0];
+  if (ImGui::IsWindowFocused()) {
+    // Handle UI interaction
+    if (ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
+      const ImVec2 clicked_pos = ImGui::GetIO().MouseClickedPos[0];
 
-    if (!was_dragging_) {
-      // Check if we need to start dragging a node or the canvas.
-      for (std::list<StatefulNode>::iterator node_iter = nodes_.begin();
-           node_iter != nodes_.end(); ++node_iter) {
-        StatefulNode& node = *node_iter;
-        if (!(hovered_node_ != nullptr && hovered_node_->node == node.node)) {
-          continue;
+      if (!was_dragging_) {
+        // Check if we need to start dragging a node or the canvas.
+        for (std::list<StatefulNode>::iterator node_iter = nodes_.begin();
+             node_iter != nodes_.end(); ++node_iter) {
+          StatefulNode& node = *node_iter;
+          if (!(hovered_node_ != nullptr && hovered_node_->node == node.node)) {
+            continue;
+          }
+
+          dragged_node_ = &node;
+          dragged_node_->dragged = true;
+          drag_start_position_ = node.position;
+
+          // Move node to end of list (to draw it on top of everything else).
+          nodes_.splice(nodes_.end(), nodes_, node_iter);
+          break;
+        }
+      }
+
+      if (bb.Contains(clicked_pos)) {
+        if (dragged_node_ == nullptr) {
+          // Dragging the canvas.
+          canvas_position_ = drag_start_position_ + ImGui::GetMouseDragDelta();
+        } else {
+          // Dragging a node.
+          dragged_node_->position = drag_start_position_ + ImGui::GetMouseDragDelta();
         }
 
-        dragged_node_ = &node;
-        dragged_node_->dragged = true;
-        drag_start_position_ = node.position;
-
-        // Move node to end of list (to draw it on top of everything else).
-        nodes_.splice(nodes_.end(), nodes_, node_iter);
-        break;
+        was_dragging_ = true;
       }
-    }
-
-    if (bb.Contains(clicked_pos)) {
-      if (dragged_node_ == nullptr) {
-        // Dragging the canvas.
-        canvas_position_ = drag_start_position_ + ImGui::GetMouseDragDelta();
-      } else {
-        // Dragging a node.
-        dragged_node_->position = drag_start_position_ + ImGui::GetMouseDragDelta();
+    } else {
+      drag_start_position_ = canvas_position_;
+      was_dragging_ = false;
+      if (dragged_node_ != nullptr) {
+        dragged_node_->dragged = false;
       }
-
-      was_dragging_ = true;
+      dragged_node_ = nullptr;
     }
-  } else {
-    drag_start_position_ = canvas_position_;
-    was_dragging_ = false;
-    if (dragged_node_ != nullptr) {
-      dragged_node_->dragged = false;
-    }
-    dragged_node_ = nullptr;
   }
 
   ImGui::PopClipRect();
@@ -230,6 +239,33 @@ void MainWindow::rootWindow() {
   canvas("play_area", ImVec2(window_size.x, window_size.y - window->DC.CursorPos.y - 4.0f),
          canvas_position_);
   ImGui::End();
+
+  const ImVec2 accounts_window_size(150.0f, 300.0f);
+  ImGui::SetNextWindowPos(ImVec2(10.0f, window_size.y - accounts_window_size.y - 12.0f));
+  ImGui::SetNextWindowSize(accounts_window_size);
+  ImGui::Begin("Accounts", nullptr,
+               ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize |
+               ImGuiWindowFlags_NoCollapse);
+  std::map<std::string, std::list<std::shared_ptr<visuals::AccountNode>>> accounts;
+  for (const StatefulNode& node : nodes_) {
+    std::shared_ptr<visuals::AccountNode> account_node = std::dynamic_pointer_cast<visuals::AccountNode>(node.node);
+    if (account_node != nullptr) {
+      accounts[account_node->getProvider()].push_back(account_node);
+    }
+  }
+
+  for (const std::pair<std::string, std::list<std::shared_ptr<visuals::AccountNode>>>& pair : accounts) {
+    if (ImGui::TreeNode(pair.first.c_str())) {
+      for (std::shared_ptr<visuals::AccountNode> account : pair.second) {
+        ImGui::BeginGroup();
+        ImGui::Text("%s", account->getAccount().c_str());
+        ImGui::EndGroup();
+      }
+      ImGui::TreePop();
+      ImGui::Separator();
+    }
+  }
+  ImGui::End();  
 }
 
 bool MainWindow::render() {

--- a/src/althack/visuals/account_node.cpp
+++ b/src/althack/visuals/account_node.cpp
@@ -1,5 +1,6 @@
 #include <althack/visuals/account_node.hpp>
 
+#include <iostream>
 #define IMGUI_DEFINE_MATH_OPERATORS
 #include <imgui_internal.h>
 
@@ -10,16 +11,32 @@ AccountNode::AccountNode(const std::string& identifier)
   : Node(identifier) {
 }
 
-void AccountNode::draw(const ImVec2 position) {
+void AccountNode::draw(const ImVec2 position, bool hovered, bool dragged) {
+  const float opacity = dragged ? 0.5 : 1.0;
   const ImVec2 nd_size = size();
-  const ImU32 col_fill = ImGui::ColorConvertFloat4ToU32(ImVec4(0.3, 0.1, 0.5, 1.0));
+  const ImU32 col_bg =
+    hovered ? ImGui::ColorConvertFloat4ToU32(ImVec4(0.9, 0.9, 0.9, opacity))
+            : ImGui::ColorConvertFloat4ToU32(ImVec4(1.0, 1.0, 1.0, opacity));
+  const ImU32 col_border =
+    hovered ? ImGui::ColorConvertFloat4ToU32(ImVec4(0.1, 0.1, 0.1, opacity))
+            : ImGui::ColorConvertFloat4ToU32(ImVec4(0.3, 0.3, 0.3, opacity));
+  const ImU32 col_shadow = ImGui::ColorConvertFloat4ToU32(ImVec4(0.3, 0.3, 0.3, 0.5 * opacity));
+  const ImVec2 shadow_offset{2.0f, 2.0f};
 
   ImDrawList* draw_list = ImGui::GetWindowDrawList();
-  draw_list->AddRectFilled(position - nd_size / 2.0, position + nd_size / 2.0, col_fill, 0.3f);
+  draw_list->AddRectFilled(position - nd_size / 2.0 + shadow_offset, position + nd_size / 2.0 + shadow_offset, col_shadow, 5.0f);
+  draw_list->AddRectFilled(position - nd_size / 2.0, position + nd_size / 2.0, col_bg, 5.0f);
+  draw_list->AddRect(position - nd_size / 2.0, position + nd_size / 2.0, col_border, 5.0f);
 }
 
 ImVec2 AccountNode::size() const {
-  return ImVec2(200, 50);
+  return ImVec2(200, 100);
+}
+
+bool AccountNode::hit(const ImVec2 node_position, const ImVec2 hit_position) const {
+  const ImVec2 node_size = size();
+  const ImRect node_rect{node_position - node_size / 2.0, node_position + node_size / 2.0};
+  return node_rect.Contains(hit_position);
 }
 
 }  // namespace visuals

--- a/src/althack/visuals/account_node.cpp
+++ b/src/althack/visuals/account_node.cpp
@@ -1,0 +1,26 @@
+#include <althack/visuals/account_node.hpp>
+
+#define IMGUI_DEFINE_MATH_OPERATORS
+#include <imgui_internal.h>
+
+namespace althack {
+namespace visuals {
+
+AccountNode::AccountNode(const std::string& identifier)
+  : Node(identifier) {
+}
+
+void AccountNode::draw(const ImVec2 position) {
+  const ImVec2 nd_size = size();
+  const ImU32 col_fill = ImGui::ColorConvertFloat4ToU32(ImVec4(0.3, 0.1, 0.5, 1.0));
+
+  ImDrawList* draw_list = ImGui::GetWindowDrawList();
+  draw_list->AddRectFilled(position - nd_size / 2.0, position + nd_size / 2.0, col_fill, 0.3f);
+}
+
+ImVec2 AccountNode::size() const {
+  return ImVec2(200, 50);
+}
+
+}  // namespace visuals
+}  // namespace althack

--- a/src/althack/visuals/account_node.cpp
+++ b/src/althack/visuals/account_node.cpp
@@ -1,14 +1,19 @@
 #include <althack/visuals/account_node.hpp>
 
-#include <iostream>
 #define IMGUI_DEFINE_MATH_OPERATORS
 #include <imgui_internal.h>
 
 namespace althack {
 namespace visuals {
 
-AccountNode::AccountNode(const std::string& identifier)
-  : Node(identifier) {
+AccountNode::AccountNode(
+    const std::string& identifier, const std::string& provider,
+    const std::string& account, double amount, const std::string& currency)
+  : Node(identifier)
+  , provider_{provider}
+  , account_{account}
+  , amount_{amount}
+  , currency_{currency} {
 }
 
 void AccountNode::draw(const ImVec2 position, bool hovered, bool dragged) {
@@ -24,19 +29,35 @@ void AccountNode::draw(const ImVec2 position, bool hovered, bool dragged) {
   const ImVec2 shadow_offset{2.0f, 2.0f};
 
   ImDrawList* draw_list = ImGui::GetWindowDrawList();
-  draw_list->AddRectFilled(position - nd_size / 2.0 + shadow_offset, position + nd_size / 2.0 + shadow_offset, col_shadow, 5.0f);
-  draw_list->AddRectFilled(position - nd_size / 2.0, position + nd_size / 2.0, col_bg, 5.0f);
-  draw_list->AddRect(position - nd_size / 2.0, position + nd_size / 2.0, col_border, 5.0f);
+  const ImVec2 top_left = position - nd_size / 2.0;
+  const ImVec2 bottom_right = position + nd_size / 2.0;
+  // Shadow
+  draw_list->AddRectFilled(top_left + shadow_offset, bottom_right + shadow_offset, col_shadow, 5.0f);
+  // Background
+  draw_list->AddRectFilled(top_left, bottom_right, col_bg, 5.0f);
+  // Border
+  draw_list->AddRect(top_left, bottom_right, col_border, 5.0f);
+
+  const ImU32 col_text = ImGui::ColorConvertFloat4ToU32(ImVec4(0.1, 0.1, 0.1, 1.0 * opacity));
+  ImVec2 text_offset{5.0f, 5.0f};
+  // Provider text
+  draw_list->AddText(top_left + text_offset, col_text, provider_.c_str());
+  text_offset += ImVec2{0.0f, 15.0f};
+  draw_list->AddText(top_left + text_offset, col_text, account_.c_str());
+  text_offset += ImVec2{0.0f, 15.0f};
+  draw_list->AddText(top_left + text_offset, col_text, (std::to_string(amount_) + " " + currency_).c_str());
 }
 
 ImVec2 AccountNode::size() const {
-  return ImVec2(200, 100);
+  return ImVec2(150, 52);
 }
 
-bool AccountNode::hit(const ImVec2 node_position, const ImVec2 hit_position) const {
-  const ImVec2 node_size = size();
-  const ImRect node_rect{node_position - node_size / 2.0, node_position + node_size / 2.0};
-  return node_rect.Contains(hit_position);
+const std::string& AccountNode::getProvider() const {
+  return provider_;
+}
+
+const std::string& AccountNode::getAccount() const {
+  return account_;
 }
 
 }  // namespace visuals

--- a/src/althack/visuals/node.cpp
+++ b/src/althack/visuals/node.cpp
@@ -1,0 +1,15 @@
+#include <althack/visuals/node.hpp>
+
+namespace althack {
+namespace visuals {
+
+Node::Node(const std::string& identifier)
+  : identifier_{identifier} {
+}
+
+const std::string& Node::getIdentifier() const {
+  return identifier_;
+}
+
+}  // namespace visuals
+}  // namespace althack

--- a/src/althack/visuals/node.cpp
+++ b/src/althack/visuals/node.cpp
@@ -1,5 +1,8 @@
 #include <althack/visuals/node.hpp>
 
+#define IMGUI_DEFINE_MATH_OPERATORS
+#include <imgui_internal.h>
+
 namespace althack {
 namespace visuals {
 
@@ -9,6 +12,12 @@ Node::Node(const std::string& identifier)
 
 const std::string& Node::getIdentifier() const {
   return identifier_;
+}
+
+bool Node::hit(const ImVec2 node_position, const ImVec2 hit_position) const {
+  const ImVec2 node_size = size();
+  const ImRect node_rect{node_position - node_size / 2.0, node_position + node_size / 2.0};
+  return node_rect.Contains(hit_position);
 }
 
 }  // namespace visuals


### PR DESCRIPTION
The canvas is able to display visual nodes at specified coordinates. The nodes move according to mouse drag of the canvas.
A base class for nodes is implemented, and an account node class is implemented that holds information on provider, account, amount, and currency.
Nodes can be moved around on the canvas (with proper visual feedback). A menu was added that reflects the currently instantiated account nodes. Two different sample nodes for accounts were added to showcase the functionality.