### PR TITLE
Integrate database into server backend

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "3rdparty/imgui"]
 	path = 3rdparty/imgui
 	url = https://github.com/ocornut/imgui.git
+[submodule "3rdparty/soci"]
+	path = 3rdparty/soci
+	url = https://github.com/SOCI/soci.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ add_executable(${PROJECT_NAME}-bin
   src/althack/main_window.cpp
   src/althack/backend.cpp
   src/althack/backends/server_backend.cpp
+  src/althack/database.cpp
   src/althack/databases/soci_database.cpp
   src/althack/visuals/node.cpp
   src/althack/visuals/account_node.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,10 +28,23 @@ add_subdirectory("docs")
 set(BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 set(BUILD_TESTS OFF CACHE BOOL "" FORCE)
 
+# SOCI cmake switches
+set(SOCI_STATIC OFF CACHE BOOL "" FORCE)
+set(SOCI_SHARED ON CACHE BOOL "" FORCE)
+set(SOCI_TESTS OFF CACHE BOOL "" FORCE)
+set(SOCI_EMPTY OFF CACHE BOOL "" FORCE)
+set(SOCI_MYSQL OFF CACHE BOOL "" FORCE)
+set(SOCI_FIREBIRD OFF CACHE BOOL "" FORCE)
+set(SOCI_ODBC OFF CACHE BOOL "" FORCE)
+set(SOCI_ORACLE OFF CACHE BOOL "" FORCE)
+set(SOCI_POSTGRESQL OFF CACHE BOOL "" FORCE)
+set(SOCI_DB2 OFF CACHE BOOL "" FORCE)
+
 # Add 3rdparty components
 add_subdirectory(${THIRDPARTY_DIR}/SDL)
 add_subdirectory(${THIRDPARTY_DIR}/libconfig)
 add_subdirectory(${THIRDPARTY_DIR}/spdlog)
+add_subdirectory(${THIRDPARTY_DIR}/soci)
 
 configure_file(include/althack/config.hpp.in include/althack/config.hpp)
 
@@ -42,7 +55,12 @@ include_directories(
   ${THIRDPARTY_DIR}/SDL/include
   ${THIRDPARTY_DIR}/libconfig/lib
   ${THIRDPARTY_DIR}/spdlog/include
+  ${THIRDPARTY_DIR}/soci/include
+  ${CMAKE_BINARY_DIR}/3rdparty/soci/include
   ${CMAKE_BINARY_DIR}/include)
+
+link_directories(
+  ${CMAKE_BINARY_DIR}/lib)
 
 add_library(imgui
   ${THIRDPARTY_DIR}/imgui/imgui.cpp
@@ -60,13 +78,17 @@ add_executable(${PROJECT_NAME}-bin
   src/althack/main_window.cpp
   src/althack/backend.cpp
   src/althack/backends/server_backend.cpp
+  src/althack/databases/soci_database.cpp
   src/althack/visuals/node.cpp
   src/althack/visuals/account_node.cpp)
 
 target_link_libraries(${PROJECT_NAME}
   imgui
   SDL2
-  config++)
+  config++
+  soci_core
+  soci_sqlite3
+  dl)
 
 target_link_libraries(${PROJECT_NAME}-bin
   ${PROJECT_NAME})

--- a/include/althack/backends/server_backend.hpp
+++ b/include/althack/backends/server_backend.hpp
@@ -1,14 +1,19 @@
 #ifndef ALTHACK_BACKENDS_SERVER_BACKEND_HPP_
 #define ALTHACK_BACKENDS_SERVER_BACKEND_HPP_
 
+// Standard
+#include <memory>
+
+// AltHack
 #include <althack/backend.hpp>
+#include <althack/database.hpp>
 
 namespace althack {
 namespace backends {
 
 class ServerBackend : public Backend {
  public:
-  ServerBackend();
+  ServerBackend(const std::string& database_file);
 
   void step() override;
 
@@ -16,6 +21,9 @@ class ServerBackend : public Backend {
 
  private:
   std::list<visuals::AccountNode> accounts_cache_;
+
+  //! \brief The database instance to use for persistent storage.
+  std::unique_ptr<Database> database_;
 };
 
 }  // namespace backends

--- a/include/althack/backends/server_backend.hpp
+++ b/include/althack/backends/server_backend.hpp
@@ -3,6 +3,7 @@
 
 // Standard
 #include <memory>
+#include <string>
 
 // AltHack
 #include <althack/backend.hpp>
@@ -14,6 +15,8 @@ namespace backends {
 class ServerBackend : public Backend {
  public:
   ServerBackend(const std::string& database_file);
+
+  ~ServerBackend();
 
   void step() override;
 

--- a/include/althack/database.hpp
+++ b/include/althack/database.hpp
@@ -1,0 +1,16 @@
+#ifndef ALTHACK_DATABASE_HPP_
+#define ALTHACK_DATABASE_HPP_
+
+namespace althack {
+
+//! \brief Abstract base class for persistent database classes
+/*!
+   This base database class provides the interface for persistent data storage in server backend
+   instances. It needs to be subclassed to add actual functionality.
+ */
+class Database {
+};
+
+}  // namespace althack
+
+#endif  // ALTHACK_DATABASE_HPP_

--- a/include/althack/database.hpp
+++ b/include/althack/database.hpp
@@ -1,6 +1,9 @@
 #ifndef ALTHACK_DATABASE_HPP_
 #define ALTHACK_DATABASE_HPP_
 
+// Standard
+#include <string>
+
 namespace althack {
 
 //! \brief Abstract base class for persistent database classes
@@ -9,6 +12,14 @@ namespace althack {
    instances. It needs to be subclassed to add actual functionality.
  */
 class Database {
+ public:
+  //! \brief Opens the database for reading/writing.
+  virtual bool open() = 0;
+  //! \brief Closes the database.
+  virtual bool close() = 0;
+
+ protected:
+  std::string getISO8601Timestamp() const;
 };
 
 }  // namespace althack

--- a/include/althack/databases/soci_database.hpp
+++ b/include/althack/databases/soci_database.hpp
@@ -1,0 +1,41 @@
+#ifndef ALTHACK_DATABASES_SOCI_DATABASE_HPP_
+#define ALTHACK_DATABASES_SOCI_DATABASE_HPP_
+
+// Standard
+#include <string>
+
+// AltHack
+#include <althack/database.hpp>
+
+// SOCI
+#include <soci/soci.h>
+
+namespace althack {
+namespace databases {
+
+//! \brief Implements the SOCI database library as AltHack database
+/*!
+  SOCI is a database abstraction layer that provides modern C++ functionality to proven database
+  interfaces like DB2, Oracle, MySQL, or SQLITE. AltHack uses the file-based SQLITE interface
+  through SOCI (v4.0.3).
+
+  SOCI's documentation can be found on SourceForge here:
+  http://soci.sourceforge.net/doc/release/4.0/
+ */
+class SociDatabase : public Database {
+ public:
+  //! \brief Initializes this database instance, using the specified filename for storage.
+  /*!
+    \param database_file The filepath to use for reading/writing the database contents.
+   */
+  SociDatabase(const std::string& database_file);
+
+ private:
+  //! \brief The database session to use.
+  soci::session session_;
+};
+
+}  // namespace databases
+}  // namespace althack
+
+#endif  // ALTHACK_DATABASES_SOCI_DATABASE_HPP_

--- a/include/althack/databases/soci_database.hpp
+++ b/include/althack/databases/soci_database.hpp
@@ -30,9 +30,15 @@ class SociDatabase : public Database {
    */
   SociDatabase(const std::string& database_file);
 
+  bool open() override;
+
+  bool close() override;
+
  private:
   //! \brief The database session to use.
   soci::session session_;
+  //! \brief The database file to use.
+  const std::string database_file_;
 };
 
 }  // namespace databases

--- a/src/althack/althack.cpp
+++ b/src/althack/althack.cpp
@@ -34,7 +34,7 @@ bool AltHack::run() {
 
   // Start backend thread
   std::atomic<bool> run_backend = true;
-  spdlog::info("Startung backend worker thread");
+  spdlog::info("Starting backend worker thread");
   std::thread backend_thread(&AltHack::backendWorker, this, std::ref(run_backend));
 
   // Run frontend loop

--- a/src/althack/althack.cpp
+++ b/src/althack/althack.cpp
@@ -20,7 +20,7 @@ bool AltHack::setup() {
   }
 
   // TODO: Decide how server/client backend is determined.
-  backend_ = std::make_unique<backends::ServerBackend>();
+  backend_ = std::make_unique<backends::ServerBackend>("database.db");
 
   spdlog::info("Using backend: " + backend_->getIdentifier());
 

--- a/src/althack/backends/server_backend.cpp
+++ b/src/althack/backends/server_backend.cpp
@@ -1,10 +1,15 @@
 #include <althack/backends/server_backend.hpp>
 
+#include <althack/databases/soci_database.hpp>
+
 namespace althack {
 namespace backends {
 
-ServerBackend::ServerBackend()
+ServerBackend::ServerBackend(const std::string& database_file)
     : Backend("server_backend") {
+  // Initialize the backend database for persistent storage.
+  database_ = std::make_unique<databases::SociDatabase>(database_file);
+
   accounts_cache_.push_back(visuals::AccountNode("node1", "rainforest", "acc123", 100.0, "$"));
   accounts_cache_.push_back(visuals::AccountNode("node2", "paybuddy", "acc@pb.domain", 52.75, "EUR"));
 }

--- a/src/althack/backends/server_backend.cpp
+++ b/src/althack/backends/server_backend.cpp
@@ -9,9 +9,14 @@ ServerBackend::ServerBackend(const std::string& database_file)
     : Backend("server_backend") {
   // Initialize the backend database for persistent storage.
   database_ = std::make_unique<databases::SociDatabase>(database_file);
+  database_->open();
 
   accounts_cache_.push_back(visuals::AccountNode("node1", "rainforest", "acc123", 100.0, "$"));
   accounts_cache_.push_back(visuals::AccountNode("node2", "paybuddy", "acc@pb.domain", 52.75, "EUR"));
+}
+
+ServerBackend::~ServerBackend() {
+  database_->close();
 }
 
 void ServerBackend::step() {

--- a/src/althack/database.cpp
+++ b/src/althack/database.cpp
@@ -1,0 +1,26 @@
+#include <althack/database.hpp>
+
+#include <ctime>
+#include <chrono>
+#include <iomanip>
+#include <sstream>
+
+namespace althack {
+
+std::string Database::getISO8601Timestamp() const {
+  const auto now = std::chrono::system_clock::now();
+  const std::time_t time = std::chrono::system_clock::to_time_t(now);
+  const std::tm* now_tm = std::localtime(&time);
+  const long long timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
+
+  std::stringstream sts;
+  sts << std::setfill('0')
+      << std::put_time(now_tm, "%FT%H:%M:")
+      << std::setw(2) << (timestamp / 1000) % 60 << '.'
+      << std::setw(3) << timestamp % 1000
+      << std::put_time(now_tm, "%z");
+
+  return sts.str();
+}
+
+}  // namespace althack

--- a/src/althack/databases/soci_database.cpp
+++ b/src/althack/databases/soci_database.cpp
@@ -1,9 +1,44 @@
 #include <althack/databases/soci_database.hpp>
 
+#include <filesystem>
+
+#include <soci/sqlite3/soci-sqlite3.h>
+
 namespace althack {
 namespace databases {
 
-SociDatabase::SociDatabase(const std::string& database_file) {
+SociDatabase::SociDatabase(const std::string& database_file)
+  : database_file_{database_file} {
+}
+
+bool SociDatabase::open() {
+  const bool exists = std::filesystem::exists(database_file_);
+  session_.open(soci::sqlite3, database_file_);
+
+  if (!exists) {
+    // Create users table
+    session_ << "CREATE TABLE users ("
+             << "user_id INTEGER PRIMARY KEY AUTOINCREMENT, "
+             << "password_hash VARCHAR(64) NOT NULL, "
+             << "user_name VARCHAR(255) NOT NULL"
+             << ")";
+    // Create stats table
+    session_ << "CREATE TABLE stats ("
+             << "stat_key varchar(255) PRIMARY KEY NOT NULL, "
+             << "stat_value varchar(255) NOT NULL"
+             << ")";
+
+    // Insert initial data
+    session_ << "INSERT INTO users(user_name, password_hash) VALUES('admin', 'somehash')";
+    session_ << "INSERT INTO stats VALUES('created_at', '" << getISO8601Timestamp() << "')";
+  }
+
+  return true;
+}
+
+bool SociDatabase::close() {
+  session_.close();
+  return true;
 }
 
 }  // namespace databases

--- a/src/althack/databases/soci_database.cpp
+++ b/src/althack/databases/soci_database.cpp
@@ -1,0 +1,10 @@
+#include <althack/databases/soci_database.hpp>
+
+namespace althack {
+namespace databases {
+
+SociDatabase::SociDatabase(const std::string& database_file) {
+}
+
+}  // namespace databases
+}  // namespace althack


### PR DESCRIPTION
To be able to store data persistently, a database storage layer needs to
be integrated into the server backend.

This change integrates SOCI as a transparent layer to SQLITE3. The
reason for this choice is that SOCI adds modern C++ mechanisms to the
file-based approach of SQLITE, which is both very much desirable for the
project.

Relates to issue #19.