### PR TITLE
Add a frontend layer to communicate with the backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ add_library(${PROJECT_NAME}
 add_executable(${PROJECT_NAME}-bin
   src/main.cpp
   src/althack/main_window.cpp
+  src/althack/frontend.cpp
   src/althack/backend.cpp
   src/althack/backends/server_backend.cpp
   src/althack/database.cpp

--- a/include/althack/althack.hpp
+++ b/include/althack/althack.hpp
@@ -20,6 +20,7 @@
 #include <althack/configuration.hpp>
 #include <althack/backend.hpp>
 #include <althack/backends/server_backend.hpp>
+#include <althack/frontend.hpp>
 #include <althack/main_window.hpp>
 
 namespace althack {
@@ -51,6 +52,8 @@ class AltHack {
  private:
   void backendWorker(std::atomic<bool>& run_flag);
 
+  void frontendWorker(std::atomic<bool>& run_flag);
+
   Configuration configuration_;
   MainWindow main_window_;
 
@@ -60,7 +63,8 @@ class AltHack {
 
   bool headless_;
 
-  std::unique_ptr<Backend> backend_;
+  std::shared_ptr<Backend> backend_;
+  Frontend frontend_;
 };
 
 }  // namespace althack

--- a/include/althack/frontend.hpp
+++ b/include/althack/frontend.hpp
@@ -1,0 +1,26 @@
+#ifndef ALTHACK_FRONTEND_HPP_
+#define ALTHACK_FRONTEND_HPP_
+
+// Standard
+#include <memory>
+
+// Althack
+#include <althack/backend.hpp>
+
+namespace althack {
+
+class Frontend {
+ public:
+  void connect(std::shared_ptr<Backend> backend);
+
+  void step();
+
+  const std::list<visuals::AccountNode> getAccounts();
+
+ private:
+  std::shared_ptr<Backend> backend_;
+};
+
+}  // namespace althack
+
+#endif  // ALTHACK_FRONTEND_HPP_

--- a/src/althack/frontend.cpp
+++ b/src/althack/frontend.cpp
@@ -1,0 +1,17 @@
+#include <althack/frontend.hpp>
+
+namespace althack {
+
+void Frontend::connect(std::shared_ptr<Backend> backend) {
+  backend_ = backend;
+}
+
+void Frontend::step() {
+  // TOOD: Implement frontend cycle work.
+}
+
+const std::list<visuals::AccountNode> Frontend::getAccounts() {
+  return backend_->getAccounts();
+}
+
+}  // namespace althack


### PR DESCRIPTION
The frontend layer can connect to either a local server backend, or to a
future proxy backend that connects to a remote server backend. The
backend interface dictates the available functionality for the frontend
instance.

The frontend requires a worker thread on its own, which communicates
with the backend, updates the UI, but does not interfere with the UI
thread OR the backend thread.